### PR TITLE
add six module as dependency; make single change in api.py

### DIFF
--- a/pymarketo/api.py
+++ b/pymarketo/api.py
@@ -123,4 +123,4 @@ class MarketoConnection(object):
         except requests.ConnectionError:
             raise MarketoAPIException('Could not connect to server')
         data = r.json()
-        return self._process(data)
+        return self.process(data)

--- a/pymarketo/api.py
+++ b/pymarketo/api.py
@@ -6,6 +6,7 @@ import os
 import json
 
 import requests
+import six
 
 from pymarketo.exceptions import MarketoAPIException
 
@@ -82,7 +83,7 @@ class MarketoConnection(object):
         result = data.get('result', [])
         for i, item in enumerate(result):
             # Strip 'None' fields from the response lead data.
-            result[i] = {k: v for k, v in item.iteritems() if v is not None}
+            result[i] = {k: v for k, v in six.iteritems(item) if v is not None}
 
             # If 'cookies' is part of lead data, split into a list by comma
             # and add the prefix to the front.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ setup(
     name='pymarketo',
     version=VERSION,
     packages=['pymarketo'],
-    install_requires=['requests>=2.8.1'],
+    install_requires=[
+        'requests>=2.8.1',
+        'six'
+        ],
 
     description='Python interface to the Marketo REST API',
     author='Jeremy Swinarton',


### PR DESCRIPTION
allows Python 3 compatibility. Am seeing error-free behavior in client with this single change. No issues related to str/unicode, since requests module handles all of that and url construction via format() doesn't touch on any encode/decode issues.

If you'd like to release a new version to PyPI after merging, my own code could use the PyPI package rather than my custom-built version of pymarketo.
